### PR TITLE
Admin should be able to edit orders

### DIFF
--- a/app/orders/api.py
+++ b/app/orders/api.py
@@ -51,3 +51,22 @@ class OrdersManagementView(MethodView):
             all_orders = Order.get_all_orders()
             return all_orders
         return jsonify({'message' : "You do not have admin rights."})
+    
+    decorators = [token_required]
+    def put(self, current_user, orderId):
+        """Update an order."""
+        order_db = OrderDbQueries()
+        data = request.get_json()
+        if current_user.username == 'admin':
+            query = order_db.fetch_by_parameter('orders', 'orderId', orderId)
+            if query:
+                order_status = ['completed', 'cancelled', 'processing', 'new']
+                status = data['status']
+                if status in  order_status:
+                    order_db.update_order_status(orderId, status)
+                    updated_order = order_db.fetch_specific_order_by_parameter('orders', 'orderId', orderId)
+                    return jsonify ({'message' : updated_order})
+                return jsonify ({'message' : 'Invalid Status.'})
+            return jsonify ({'message' : "Order not found."})
+        return jsonify({'message' : "You do not have admin rights."})
+        

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -134,6 +134,63 @@ class TestOrder(TestBase):
                                             self.get_admin_token()})
         self.assertIn('Order not found.', str(response.data))
         self.assertEqual(response.status_code, 404)
+    
+
+
+
+     def test_admin_updating_specific_orders(self):
+        """ Tests admin updating a specific order. """
+        self.create_valid_product()
+        self.create_valid_order()
+        response = self.client.put('/api/v2/orders/1',
+                                   data=json.dumps(self.valid_update),
+                                   content_type='application/json',
+                                   headers={'Authorization':
+                                            self.get_admin_token()})
+        self.assertEqual(response.status_code, 200)
+
+
+
+    def test_admin_updating_non_existing_order(self):
+        """ Tests admin updating a non existing order."""
+        self.create_valid_product()
+        self.create_valid_order()
+        response = self.client.put('/api/v2/orders/6',
+                                   data=json.dumps(self.valid_update),
+                                   content_type='application/json',
+                                   headers={'Authorization':
+                                            self.get_admin_token()})
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('Order not found.', str(response.data))
+
+    def test_admin_updating_order_with_invalid_status(self):
+        """ Tests admin updating a specific order with invalid status. """
+        self.create_valid_product()
+        self.create_valid_order()
+        response = self.client.put('/api/v2/orders/1',
+                                   data=json.dumps(self.invalid_update),
+                                   content_type='application/json',
+                                   headers={'Authorization':
+                                            self.get_admin_token()})
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('Invalid Status.', str(response.data))
+
+    def test_non_admin_updating_order(self):
+        """ Tests non admin updating an order. """
+        response = self.client.post('/api/v2/auth/signup',
+                                    data=json.dumps(self.valid_non_admin_user),
+                                    content_type='application/json')
+        self.create_valid_product()
+        self.create_valid_order()
+        response = self.client.put('/api/v2/orders/1',
+                                   data=json.dumps(self.valid_order),
+                                   content_type='application/json',
+                                   headers={'Authorization':
+                                            self.get_non_admin_token()})
+        self.assertIn('You do not have admin rights.', str(response.data))
+        self.assertEqual(response.status_code, 200)
+
+   
 
 
 

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -190,7 +190,3 @@ class TestOrder(TestBase):
         self.assertIn('You do not have admin rights.', str(response.data))
         self.assertEqual(response.status_code, 200)
 
-   
-
-
-


### PR DESCRIPTION
### What does this PR do?
- This PR adds functionality for admin editing single orders.
### Description of Task to be completed
-  Configure models, views and add tests.
-  Closes #16  
### How to test
- Access endpoint: `http://127.0.0.1:5000/api/v2/orders/<int:orderId>`